### PR TITLE
fix: stabilize gutter ownership across concurrent edits and restart/reconnect

### DIFF
--- a/cursorOverlay.js
+++ b/cursorOverlay.js
@@ -99,25 +99,35 @@ function _renderAuthorshipGutter() {
 
   const text = _textarea.value || "";
   const scrollTop = _textarea.scrollTop;
-  for (const [lineStr, info] of Object.entries(_lineAuthors)) {
-    const line = parseInt(lineStr, 10);
-    if (!Number.isFinite(line) || line < 1 || !info?.color) continue;
+  const totalLines = (text.match(/\n/g) || []).length + 1;
+  const entries = Object.entries(_lineAuthors)
+    .map(([lineStr, info]) => ({ line: parseInt(lineStr, 10), info }))
+    .filter((entry) => Number.isFinite(entry.line) && entry.line >= 1 && entry.info?.color)
+    .sort((a, b) => a.line - b.line);
 
-    const lineStart = _lineToOffset(text, line);
-    const coords = _getCaretCoords(text, lineStart);
-    if (!coords) continue;
+  for (let i = 0; i < entries.length; i += 1) {
+    const current = entries[i];
+    const next = entries[i + 1];
+    const startLine = current.line;
+    const endLine = Math.min(totalLines, Math.max(startLine, next ? next.line - 1 : totalLines));
+    if (startLine > totalLines || endLine < startLine) continue;
 
-    const nextLineStart = _lineToOffset(text, line + 1);
-    const nextCoords = nextLineStart > lineStart ? _getCaretCoords(text, nextLineStart) : null;
-    const lineHeight = nextCoords ? Math.max(coords.lh, nextCoords.top - coords.top) : coords.lh;
+    const startOffset = _lineToOffset(text, startLine);
+    const endOffset = _lineToOffset(text, endLine + 1);
+    const startCoords = _getCaretCoords(text, startOffset);
+    const endCoords = endOffset > startOffset ? _getCaretCoords(text, endOffset) : null;
+    if (!startCoords) continue;
 
-    const top = coords.top - scrollTop;
-    if (top + lineHeight < 0 || top > _textarea.clientHeight + coords.lh) continue;
+    const lineHeight = endCoords
+      ? Math.max(startCoords.lh, endCoords.top - startCoords.top)
+      : startCoords.lh;
+    const top = startCoords.top - scrollTop;
+    if (top + lineHeight < 0 || top > _textarea.clientHeight + startCoords.lh) continue;
 
-    const name = _resolveAuthorName(info);
+    const name = _resolveAuthorName(current.info);
     const mark = document.createElement("div");
     mark.className = "author-gutter-mark";
-    mark.style.cssText = `top:${top}px;height:${lineHeight}px;background:${info.color};--peer-color:${info.color};`;
+    mark.style.cssText = `top:${top}px;height:${lineHeight}px;background:${current.info.color};--peer-color:${current.info.color};`;
     mark.dataset.peerName = name;
     mark.title = name;
     _authorGutterEl.appendChild(mark);

--- a/p2p.js
+++ b/p2p.js
@@ -74,6 +74,7 @@ let reconnectTimer = null;
 let isRecoveringYjsState = false;
 const MAX_PENDING_UPDATE_BYTES = 2 * 1024 * 1024;
 const Y_ORIGIN_REMOTE = "remote-sse";
+const Y_ORIGIN_LOCAL = "local-input";
 
 const ROOM_STATE_PREFIX = "p2pmd-room-";
 const ROOM_CONTENT_PREFIX = "p2pmd-room-content-";
@@ -109,6 +110,44 @@ let lastPresencePayload = "";
 const onboardingPage = document.getElementById("onboarding-page");
 const onboardingNameInput = document.getElementById("onboarding-name");
 const onboardingSubmitButton = document.getElementById("onboard-submit");
+
+function diffLineAttributionMaps(beforeMap, afterMap) {
+  const before = normalizeLineAttributions(beforeMap) || {};
+  const after = normalizeLineAttributions(afterMap) || {};
+  const beforeKeys = new Set(Object.keys(before));
+  const afterKeys = new Set(Object.keys(after));
+  const added = [];
+  const removed = [];
+  const changed = [];
+
+  for (const line of afterKeys) {
+    if (!beforeKeys.has(line)) {
+      added.push(line);
+      continue;
+    }
+    const b = before[line];
+    const a = after[line];
+    if ((b?.color || "") !== (a?.color || "") || (b?.name || "") !== (a?.name || "")) {
+      changed.push(line);
+    }
+  }
+  for (const line of beforeKeys) {
+    if (!afterKeys.has(line)) removed.push(line);
+  }
+
+  const numericSort = (x, y) => Number(x) - Number(y);
+  added.sort(numericSort);
+  removed.sort(numericSort);
+  changed.sort(numericSort);
+  return {
+    addedCount: added.length,
+    removedCount: removed.length,
+    changedCount: changed.length,
+    addedPreview: added.slice(0, 12),
+    removedPreview: removed.slice(0, 12),
+    changedPreview: changed.slice(0, 12)
+  };
+}
 
 const publishCSS = `
   @font-face {
@@ -1086,9 +1125,9 @@ export function scheduleSend() {
     prevText = oldText;
     return;
   }
-  _attributeCurrentLine();
+  applyTextDiff(ytext, oldText, newText, Y_ORIGIN_LOCAL);
+  _attributeLocalEditRange(oldText, newText);
   updateLineAuthors(_roomLineAttributions);
-  applyTextDiff(ytext, oldText, newText);
   prevText = newText;
 }
 
@@ -1104,9 +1143,78 @@ function _attributeCurrentLine() {
     const name  = getDisplayName() || truncateIdentifier(localClientId, PEER_FALLBACK_NAME_LEN);
     const color = currentPeerList.find((p) => p.clientId === localClientId)?.color || _localFallbackColor();
     if (!color) return;
-    _localLineAttributions[String(line)] = { name, color };
-    _roomLineAttributions[String(line)] = { name, color };
+    const entry = { name, color, clientId: localClientId || "", updatedAt: Date.now() };
+    _localLineAttributions[String(line)] = entry;
+    _roomLineAttributions[String(line)] = entry;
     scheduleRoomLineAttributionsPersist();
+  } catch {}
+}
+
+function _attributeLocalEditRange(oldText, newText) {
+  try {
+    const oldValue = typeof oldText === "string" ? oldText : "";
+    const newValue = typeof newText === "string" ? newText : "";
+    if (oldValue === newValue) return;
+
+    let prefixLen = 0;
+    let oldSuffix = oldValue.length;
+    let newSuffix = newValue.length;
+
+    const isPurePrepend = newValue.length > oldValue.length && newValue.endsWith(oldValue);
+    const isPureAppend = newValue.length > oldValue.length && newValue.startsWith(oldValue);
+
+    if (isPurePrepend) {
+      prefixLen = 0;
+      oldSuffix = 0;
+      newSuffix = newValue.length - oldValue.length;
+    } else if (isPureAppend) {
+      prefixLen = oldValue.length;
+      oldSuffix = oldValue.length;
+      newSuffix = newValue.length;
+    } else {
+   
+      const minLen = Math.min(oldValue.length, newValue.length);
+      while (prefixLen < minLen && oldValue[prefixLen] === newValue[prefixLen]) prefixLen += 1;
+      while (oldSuffix > prefixLen && newSuffix > prefixLen &&
+            oldValue[oldSuffix - 1] === newValue[newSuffix - 1]) {
+        oldSuffix -= 1;
+        newSuffix -= 1;
+      }
+    }
+
+    const deleteLen = oldSuffix - prefixLen;
+    const inserted = newValue.slice(prefixLen, newSuffix);
+    const syntheticDelta = [];
+    if (prefixLen > 0) syntheticDelta.push({ retain: prefixLen });
+    if (deleteLen > 0) syntheticDelta.push({ delete: deleteLen });
+    if (inserted) syntheticDelta.push({ insert: inserted });
+
+    if (syntheticDelta.length > 0) {
+      const shiftedRoom = shiftLineAttributionsByDelta(_roomLineAttributions, oldValue, syntheticDelta);
+      if (shiftedRoom.changed) _roomLineAttributions = shiftedRoom.map;
+      const shiftedLocal = shiftLineAttributionsByDelta(_localLineAttributions, oldValue, syntheticDelta);
+      if (shiftedLocal.changed) _localLineAttributions = shiftedLocal.map;
+    }
+
+    let startLine = lineNumberAtOffset(newValue, prefixLen);
+    let touchedLineCount = 1;
+    if (inserted.length > 0) {
+      const insertionAtLineStart = isOffsetAtLineStart(oldValue, prefixLen);
+      const startsWithNewline = inserted.startsWith("\n");
+      const endsWithNewline = inserted.endsWith("\n");
+
+      if (!insertionAtLineStart && startsWithNewline) {
+        startLine += 1;
+      }
+
+      touchedLineCount = countLineBreaks(inserted) + (endsWithNewline ? 0 : 1);
+      if (!insertionAtLineStart && startsWithNewline) {
+        touchedLineCount -= 1;
+      }
+      touchedLineCount = Math.max(1, touchedLineCount);
+    }
+    const endLine = startLine + touchedLineCount - 1;
+    attributeLocalLineRange(startLine, endLine);
   } catch {}
 }
 
@@ -1125,6 +1233,7 @@ function attributeLocalLineRange(startLine, endLine, { reset = false } = {}) {
   const name = getDisplayName() || truncateIdentifier(localClientId, PEER_FALLBACK_NAME_LEN);
   const color = currentPeerList.find((p) => p.clientId === localClientId)?.color || _localFallbackColor();
   if (!color) return;
+  const now = Date.now();
 
   if (reset) {
     _localLineAttributions = {};
@@ -1133,7 +1242,12 @@ function attributeLocalLineRange(startLine, endLine, { reset = false } = {}) {
 
   for (let line = start; line <= end; line += 1) {
     const lineKey = String(line);
-    const entry = { name, color };
+    const entry = {
+      name,
+      color,
+      clientId: localClientId || "",
+      updatedAt: now
+    };
     _localLineAttributions[lineKey] = entry;
     _roomLineAttributions[lineKey] = entry;
   }
@@ -1151,7 +1265,7 @@ export function attributeLocalWholeDocument({ reset = false, broadcastPresence =
   }
 }
 
-function mergeLineAttributionsIntoRoom(value) {
+function mergeLineAttributionsIntoRoom(value, source = "unknown") {
   if (!value || typeof value !== "object") return;
   let changed = false;
   for (const [line, info] of Object.entries(value)) {
@@ -1160,19 +1274,44 @@ function mergeLineAttributionsIntoRoom(value) {
     if (!info || typeof info !== "object" || typeof info.color !== "string") continue;
     const lineKey = String(Math.floor(lineNum));
     const prevValue = _roomLineAttributions[lineKey];
+    const incomingUpdatedAt = Number.isFinite(Number(info.updatedAt)) ? Number(info.updatedAt) : 0;
+    const incomingClientId = typeof info.clientId === "string" ? info.clientId : "";
+    const prevUpdatedAt = Number.isFinite(Number(prevValue?.updatedAt)) ? Number(prevValue.updatedAt) : 0;
+    const prevClientId = typeof prevValue?.clientId === "string" ? prevValue.clientId : "";
+
+    if (
+      prevValue &&
+      compareLineAttributionCandidates(
+        { updatedAt: incomingUpdatedAt, clientId: incomingClientId },
+        { updatedAt: prevUpdatedAt, clientId: prevClientId }
+      ) < 0
+    ) {
+      continue;
+    }
+
     const incomingName = typeof info.name === "string" ? info.name.trim() : "";
     const colorMatchedPeer = currentPeerList.find((peer) => peer?.color === info.color && peer?.name);
     const resolvedName = incomingName || colorMatchedPeer?.name || prevValue?.name || "";
     const nextValue = {
       name: resolvedName,
-      color: info.color
+      color: info.color,
+      clientId: incomingClientId || prevClientId || "",
+      updatedAt: incomingUpdatedAt || prevUpdatedAt || 0
     };
-    if (!prevValue || prevValue.name !== nextValue.name || prevValue.color !== nextValue.color) {
+    if (
+      !prevValue ||
+      prevValue.name !== nextValue.name ||
+      prevValue.color !== nextValue.color ||
+      (prevValue.clientId || "") !== (nextValue.clientId || "") ||
+      Number(prevValue.updatedAt || 0) !== Number(nextValue.updatedAt || 0)
+    ) {
       _roomLineAttributions[lineKey] = nextValue;
       changed = true;
     }
   }
-  if (changed) scheduleRoomLineAttributionsPersist();
+  if (changed) {
+    scheduleRoomLineAttributionsPersist();
+  }
 }
 
 function refreshRoomAttributionNamesFromPeerList() {
@@ -1193,6 +1332,7 @@ function refreshRoomAttributionNamesFromPeerList() {
     const [resolvedName] = Array.from(names);
     if (resolvedName && info.name !== resolvedName) {
       _roomLineAttributions[lineKey] = {
+        ...info,
         name: resolvedName,
         color: info.color
       };
@@ -1207,6 +1347,140 @@ function refreshRoomAttributionNamesFromPeerList() {
 
 function refreshLocalLineAttribution() {
   updateLineAuthors(_roomLineAttributions);
+}
+
+function countLineBreaks(value) {
+  if (typeof value !== "string" || value.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] === "\n") count += 1;
+  }
+  return count;
+}
+
+function lineNumberAtOffset(text, offset) {
+  const source = typeof text === "string" ? text : "";
+  const clamped = Math.max(0, Math.min(Number(offset) || 0, source.length));
+  let line = 1;
+  for (let i = 0; i < clamped; i += 1) {
+    if (source[i] === "\n") line += 1;
+  }
+  return line;
+}
+
+function isOffsetAtLineStart(text, offset) {
+  const source = typeof text === "string" ? text : "";
+  const clamped = Math.max(0, Math.min(Number(offset) || 0, source.length));
+  return clamped === 0 || source[clamped - 1] === "\n";
+}
+
+function shiftLineAttributionsAfterLine(
+  map,
+  afterLineExclusive,
+  lineDelta,
+  { dropRangeStart = null, dropRangeEnd = null } = {}
+) {
+  if (!map || typeof map !== "object" || !Number.isFinite(lineDelta) || lineDelta === 0) {
+    return { changed: false, map };
+  }
+  const normalized = normalizeLineAttributions(map) || {};
+  const lineNumbers = Object.keys(normalized)
+    .map((line) => Number(line))
+    .filter((line) => Number.isFinite(line) && line >= 1)
+    .sort((a, b) => a - b);
+
+  let changed = false;
+  const shifted = {};
+  const hasDropRange = Number.isFinite(dropRangeStart) && Number.isFinite(dropRangeEnd) && dropRangeEnd >= dropRangeStart;
+  for (const line of lineNumbers) {
+    const lineKey = String(line);
+    const entry = normalized[lineKey];
+    if (hasDropRange && line >= dropRangeStart && line <= dropRangeEnd) {
+      changed = true;
+      continue;
+    }
+    const nextLine = line > afterLineExclusive ? line + lineDelta : line;
+    if (nextLine !== line) changed = true;
+    if (nextLine < 1) {
+      changed = true;
+      continue;
+    }
+    const nextLineKey = String(nextLine);
+    if (Object.prototype.hasOwnProperty.call(shifted, nextLineKey)) {
+      changed = true;
+      continue;
+    }
+    shifted[nextLineKey] = entry;
+  }
+  return changed ? { changed: true, map: shifted } : { changed: false, map };
+}
+
+function shiftLineAttributionsByDelta(map, oldText, delta) {
+  if (!map || typeof map !== "object" || !Array.isArray(delta) || delta.length === 0) {
+    return { changed: false, map, operations: [] };
+  }
+  let working = map;
+  let changed = false;
+  let oldCursor = 0;
+  const operations = [];
+  const baseText = typeof oldText === "string" ? oldText : "";
+
+  for (const op of delta) {
+    if (op && typeof op.retain === "number" && op.retain > 0) {
+      oldCursor += op.retain;
+      continue;
+    }
+    if (op && typeof op.insert === "string") {
+      const insertedLineBreaks = countLineBreaks(op.insert);
+      if (insertedLineBreaks > 0) {
+        const anchorLine = lineNumberAtOffset(baseText, oldCursor);
+        const afterLineExclusive = isOffsetAtLineStart(baseText, oldCursor)
+          ? anchorLine - 1
+          : anchorLine;
+        const shifted = shiftLineAttributionsAfterLine(working, afterLineExclusive, insertedLineBreaks);
+        if (shifted.changed) {
+          working = shifted.map;
+          changed = true;
+          operations.push({
+            kind: "insert",
+            atOffset: oldCursor,
+            afterLineExclusive,
+            lineDelta: insertedLineBreaks
+          });
+        }
+      }
+      continue;
+    }
+    if (op && typeof op.delete === "number" && op.delete > 0) {
+      const deletedSlice = baseText.slice(oldCursor, Math.min(baseText.length, oldCursor + op.delete));
+      const deletedLineBreaks = countLineBreaks(deletedSlice);
+      if (deletedLineBreaks > 0) {
+        const anchorLine = lineNumberAtOffset(baseText, oldCursor);
+        const deletedStartLine = anchorLine + 1;
+        const deletedEndLine = anchorLine + deletedLineBreaks;
+        const shifted = shiftLineAttributionsAfterLine(
+          working,
+          deletedEndLine,
+          -deletedLineBreaks,
+          { dropRangeStart: deletedStartLine, dropRangeEnd: deletedEndLine }
+        );
+        if (shifted.changed) {
+          working = shifted.map;
+          changed = true;
+          operations.push({
+            kind: "delete",
+            atOffset: oldCursor,
+            afterLineExclusive: deletedEndLine,
+            removedLines: [deletedStartLine, deletedEndLine],
+            lineDelta: -deletedLineBreaks
+          });
+        }
+      }
+      oldCursor += op.delete;
+    }
+  }
+
+  return changed ? { changed: true, map: working, operations } : { changed: false, map, operations: [] };
 }
 
 function syncLocalLineAttributionNames() {
@@ -1253,17 +1527,32 @@ function base64ToBytes(b64) {
 }
 function applyTextDiff(ytextRef, oldText, newText, origin = null) {
   if (!ytextRef || oldText === newText) return;
-  // Trim unchanged edges so we emit one minimal delete/insert change.
   let prefixLen = 0;
-  const minLen = Math.min(oldText.length, newText.length);
-  while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) prefixLen++;
   let oldSuffix = oldText.length;
   let newSuffix = newText.length;
-  while (oldSuffix > prefixLen && newSuffix > prefixLen &&
-         oldText[oldSuffix - 1] === newText[newSuffix - 1]) {
-    oldSuffix--;
-    newSuffix--;
+
+  const isPurePrepend = newText.length > oldText.length && newText.endsWith(oldText);
+  const isPureAppend = newText.length > oldText.length && newText.startsWith(oldText);
+
+  if (isPurePrepend) {
+    prefixLen = 0;
+    oldSuffix = 0;
+    newSuffix = newText.length - oldText.length;
+  } else if (isPureAppend) {
+    prefixLen = oldText.length;
+    oldSuffix = oldText.length;
+    newSuffix = newText.length;
+  } else {
+    // Trim unchanged edges so we emit one minimal delete/insert change.
+    const minLen = Math.min(oldText.length, newText.length);
+    while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) prefixLen++;
+    while (oldSuffix > prefixLen && newSuffix > prefixLen &&
+          oldText[oldSuffix - 1] === newText[newSuffix - 1]) {
+      oldSuffix--;
+      newSuffix--;
+    }
   }
+
   const deleteLen = oldSuffix - prefixLen;
   const insertStr = newText.slice(prefixLen, newSuffix);
   ytextRef.doc.transact(() => {
@@ -1620,10 +1909,23 @@ function normalizeLineAttributions(value) {
     if (!info || typeof info !== "object" || typeof info.color !== "string") continue;
     normalized[String(Math.floor(lineNum))] = {
       name: typeof info.name === "string" ? info.name : "",
-      color: info.color
+      color: info.color,
+      clientId: typeof info.clientId === "string" ? info.clientId : "",
+      updatedAt: Number.isFinite(Number(info.updatedAt)) ? Number(info.updatedAt) : 0
     };
   }
   return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function compareLineAttributionCandidates(a, b) {
+  const aUpdatedAt = Number.isFinite(Number(a?.updatedAt)) ? Number(a.updatedAt) : 0;
+  const bUpdatedAt = Number.isFinite(Number(b?.updatedAt)) ? Number(b.updatedAt) : 0;
+  if (aUpdatedAt !== bUpdatedAt) return aUpdatedAt - bUpdatedAt;
+
+  const aClientId = typeof a?.clientId === "string" ? a.clientId : "";
+  const bClientId = typeof b?.clientId === "string" ? b.clientId : "";
+  if (aClientId === bClientId) return 0;
+  return aClientId.localeCompare(bClientId);
 }
 
 function buildPeersPageHref(key = currentRoomKey, localUrl = currentRoomUrl) {
@@ -1687,37 +1989,63 @@ function persistPeerActivitySnapshot() {
 
 function setPeerList(peerList) {
   currentPeerList = normalizePeerList(peerList);
+  // Resolve attribution conflicts deterministically per line.
+  // This removes peer-order dependence in setPeerList() updates.
+  const winningAttributionsByLine = new Map();
   for (const peer of currentPeerList) {
-    if (peer?.clientId === localClientId && peer.lineAttributions && typeof peer.lineAttributions === "object") {
-      // Do not let self peerlist payload overwrite already-attributed room lines.
-      // But do allow safe name refresh on existing self-owned lines.
-      const selfSafeAttributions = {};
-      let renamedExisting = false;
-      for (const [line, info] of Object.entries(peer.lineAttributions)) {
-        const lineNum = Number(line);
-        if (!Number.isFinite(lineNum) || lineNum < 1) continue;
-        const lineKey = String(Math.floor(lineNum));
-        const existing = _roomLineAttributions[lineKey];
-        if (existing) {
-          const incomingName = typeof info?.name === "string" ? info.name.trim() : "";
-          const incomingColor = typeof info?.color === "string" ? info.color : "";
-          if (incomingName && incomingColor && existing.color === incomingColor && existing.name !== incomingName) {
-            _roomLineAttributions[lineKey] = {
-              name: incomingName,
-              color: existing.color
-            };
-            renamedExisting = true;
-          }
-          continue;
-        }
-        selfSafeAttributions[lineKey] = info;
+    if (!peer) continue;
+    const peerId = typeof peer.clientId === "string" ? peer.clientId : "";
+    const peerUpdatedAt = Number.isFinite(Number(peer.updatedAt)) ? Number(peer.updatedAt) : 0;
+    const normalizedPeerAttributions = normalizeLineAttributions(peer.lineAttributions) || {};
+    for (const [line, info] of Object.entries(normalizedPeerAttributions)) {
+      if (!info || typeof info !== "object" || typeof info.color !== "string") continue;
+      const candidate = {
+        clientId: typeof info.clientId === "string" && info.clientId ? info.clientId : peerId,
+        updatedAt: Number.isFinite(Number(info.updatedAt)) ? Number(info.updatedAt) : peerUpdatedAt,
+        name: typeof info.name === "string" ? info.name : "",
+        color: info.color
+      };
+      const existing = winningAttributionsByLine.get(line);
+      if (!existing || compareLineAttributionCandidates(candidate, existing) > 0) {
+        winningAttributionsByLine.set(line, candidate);
       }
-      mergeLineAttributionsIntoRoom(selfSafeAttributions);
-      if (renamedExisting) scheduleRoomLineAttributionsPersist();
-      continue;
     }
-    mergeLineAttributionsIntoRoom(peer.lineAttributions);
   }
+
+  // Always include the local authoritative map so recent local edits don't get
+  // temporarily dropped while peer-list propagation catches up.
+  const normalizedLocalAttributions = normalizeLineAttributions(_localLineAttributions) || {};
+  for (const [line, info] of Object.entries(normalizedLocalAttributions)) {
+    if (!info || typeof info !== "object" || typeof info.color !== "string") continue;
+    const candidate = {
+      clientId: typeof info.clientId === "string" && info.clientId ? info.clientId : localClientId,
+      updatedAt: Number.isFinite(Number(info.updatedAt)) ? Number(info.updatedAt) : 0,
+      name: typeof info.name === "string" ? info.name : "",
+      color: info.color
+    };
+    const existing = winningAttributionsByLine.get(line);
+    if (!existing || compareLineAttributionCandidates(candidate, existing) > 0) {
+      winningAttributionsByLine.set(line, candidate);
+    }
+  }
+
+  const deterministicMergedAttributions = {};
+  const sortedWinningLines = Array.from(winningAttributionsByLine.keys()).sort((a, b) => Number(a) - Number(b));
+  for (const lineKey of sortedWinningLines) {
+    const winner = winningAttributionsByLine.get(lineKey);
+    deterministicMergedAttributions[lineKey] = {
+      name: winner?.name || "",
+      color: winner?.color || "",
+      clientId: winner?.clientId || "",
+      updatedAt: Number.isFinite(Number(winner?.updatedAt)) ? Number(winner.updatedAt) : 0
+    };
+  }
+  const roomDiff = diffLineAttributionMaps(_roomLineAttributions, deterministicMergedAttributions);
+  _roomLineAttributions = deterministicMergedAttributions;
+  if (roomDiff.addedCount || roomDiff.removedCount || roomDiff.changedCount) {
+    scheduleRoomLineAttributionsPersist();
+  }
+
   refreshRoomAttributionNamesFromPeerList();
   const hostWithLatexMode = currentPeerList.find(
     (peer) => peer?.role === "host" && typeof peer.latexModeEnabled === "boolean"
@@ -2147,6 +2475,32 @@ async function connectToRoom(localUrl, role = "client") {
 
     ytext.observe((event) => {
       const newContent = ytext.toString();
+      const oldContent = prevText;
+      const delta = Array.from(event.changes.delta);
+      const beforeRoomMap = _roomLineAttributions;
+      const beforeLocalMap = _localLineAttributions;
+      const origin = event?.transaction?.origin;
+
+      if (origin !== Y_ORIGIN_LOCAL) {
+        const shiftedRoom = shiftLineAttributionsByDelta(beforeRoomMap, oldContent, delta);
+        const shiftedLocal = shiftLineAttributionsByDelta(beforeLocalMap, oldContent, delta);
+        if (shiftedRoom.changed) {
+          _roomLineAttributions = shiftedRoom.map;
+        }
+        if (shiftedLocal.changed) {
+          _localLineAttributions = shiftedLocal.map;
+        }
+        if (shiftedRoom.changed || shiftedLocal.changed) {
+          scheduleRoomLineAttributionsPersist();
+          updateLineAuthors(_roomLineAttributions);
+          // Remote edits can shift this peer's authored line numbers; publish the
+          // shifted local attribution map immediately so other peers don't lag.
+          if (shiftedLocal.changed) {
+            schedulePresenceSend(true);
+          }
+        }
+      }
+
       // Keep baseline aligned to authoritative CRDT text
       prevText = newContent;
       if (newContent === markdownInput.value) return;
@@ -2155,7 +2509,7 @@ async function connectToRoom(localUrl, role = "client") {
       let s = markdownInput.selectionStart ?? 0;
       let e = markdownInput.selectionEnd ?? 0;
       let pos = 0;
-      for (const d of event.changes.delta) {
+      for (const d of delta) {
         if (d.retain) {
           pos += d.retain;
         } else if (d.insert) {
@@ -2175,6 +2529,9 @@ async function connectToRoom(localUrl, role = "client") {
         Math.max(0, Math.min(s, newContent.length)),
         Math.max(0, Math.min(e, newContent.length))
       );
+      // Remote text applies do not fire input events; force gutter refresh so
+      // previously-merged attribution lines are re-laid out against new content.
+      updateLineAuthors(_roomLineAttributions);
       renderPreview();
       scheduleDraftSave();
     });
@@ -3754,10 +4111,16 @@ markdownInput.addEventListener("paste", (event) => {
   const text = markdownInput.value || "";
   const offset = Number.isFinite(markdownInput.selectionStart) ? markdownInput.selectionStart : 0;
   const before = text.slice(0, Math.min(offset, text.length));
+  const insertionAtLineStart = isOffsetAtLineStart(text, offset);
+  const startsWithNewline = pastedText.startsWith("\n");
+  const endsWithNewline = pastedText.endsWith("\n");
   let startLine = 1;
   for (const ch of before) if (ch === "\n") startLine += 1;
+  if (!insertionAtLineStart && startsWithNewline) startLine += 1;
 
-  const pastedLineCount = (pastedText.match(/\n/g) || []).length + 1;
+  let pastedLineCount = countLineBreaks(pastedText) + (endsWithNewline ? 0 : 1);
+  if (!insertionAtLineStart && startsWithNewline) pastedLineCount -= 1;
+  pastedLineCount = Math.max(1, pastedLineCount);
   const endLine = startLine + pastedLineCount - 1;
 
   setTimeout(() => {

--- a/p2p.js
+++ b/p2p.js
@@ -98,6 +98,7 @@ const TYPING_IDLE_MS = 1200;
 const PEER_FALLBACK_NAME_LEN = 8;
 const saveDelay = 2000;
 let hyperSaveInFlight = false;
+let lineAttributionHyperSaveInFlight = false;
 let draftSaveInFlight = false;
 const draftSnapshotCache = new Map();
 let currentPeerList = [];
@@ -505,6 +506,18 @@ function clearLocalLineAttributions(roomKey) {
   }
 }
 
+function filterLineAttributionsByClientId(lineAttributions, clientId) {
+  if (!clientId) return {};
+  const normalized = normalizeLineAttributions(lineAttributions);
+  if (!normalized) return {};
+  const filtered = {};
+  for (const [line, info] of Object.entries(normalized)) {
+    if ((info?.clientId || "") !== clientId) continue;
+    filtered[line] = info;
+  }
+  return filtered;
+}
+
 function persistRoomLineAttributionsNow() {
   if (!currentRoomKey) return;
   const normalizedRoom = normalizeLineAttributions(_roomLineAttributions);
@@ -533,6 +546,7 @@ function persistRoomLineAttributionsNow() {
       updatedAt: Date.now()
     }));
   }
+  saveRoomLineAttributionsToHyperdrive(currentRoomKey, normalizedRoom);
 }
 
 function scheduleRoomLineAttributionsPersist() {
@@ -946,6 +960,12 @@ function parseLocalUrl(value) {
   return { host: trimmed, port: null };
 }
 
+function parseBooleanParam(value) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
 function normalizeRoomKey(key) {
   if (!key || typeof key !== "string") return "";
   return key.trim();
@@ -994,6 +1014,8 @@ function updateRoomUrl(state) {
     if (state.localUrl) params.set("localUrl", state.localUrl);
     if (typeof state.secure === "boolean") params.set("secure", String(state.secure));
     if (typeof state.udp === "boolean") params.set("udp", String(state.udp));
+    if (typeof state.hosted === "boolean") params.set("hosted", String(state.hosted));
+    if (typeof state.creator === "boolean") params.set("creator", String(state.creator));
     if (state.host) params.set("host", state.host);
     if (state.port) params.set("port", String(state.port));
   } else {
@@ -1001,6 +1023,8 @@ function updateRoomUrl(state) {
     params.delete("localUrl");
     params.delete("secure");
     params.delete("udp");
+    params.delete("hosted");
+    params.delete("creator");
     params.delete("host");
     params.delete("port");
   }
@@ -1014,11 +1038,15 @@ function readRoomStateFromUrl() {
   const params = new URLSearchParams(window.location.search);
   const key = normalizeRoomKey(params.get("roomKey") || "");
   if (!key) return null;
+  const hosted = parseBooleanParam(params.get("hosted"));
+  const creator = parseBooleanParam(params.get("creator"));
   return {
     key,
     localUrl: params.get("localUrl") || "",
     secure: params.get("secure") === "true",
     udp: params.get("udp") === "true",
+    ...(hosted === null ? {} : { hosted }),
+    ...(creator === null ? {} : { creator }),
     host: params.get("host") || "",
     port: normalizePort(params.get("port"), null)
   };
@@ -1184,6 +1212,8 @@ function _attributeLocalEditRange(oldText, newText) {
 
     const deleteLen = oldSuffix - prefixLen;
     const inserted = newValue.slice(prefixLen, newSuffix);
+    const deletedSlice = deleteLen > 0 ? oldValue.slice(prefixLen, oldSuffix) : "";
+    const deletedLineBreaks = countLineBreaks(deletedSlice);
     const syntheticDelta = [];
     if (prefixLen > 0) syntheticDelta.push({ retain: prefixLen });
     if (deleteLen > 0) syntheticDelta.push({ delete: deleteLen });
@@ -1194,6 +1224,12 @@ function _attributeLocalEditRange(oldText, newText) {
       if (shiftedRoom.changed) _roomLineAttributions = shiftedRoom.map;
       const shiftedLocal = shiftLineAttributionsByDelta(_localLineAttributions, oldValue, syntheticDelta);
       if (shiftedLocal.changed) _localLineAttributions = shiftedLocal.map;
+    }
+
+
+    if (deleteLen > 0 && inserted.length === 0 && deletedLineBreaks > 0) {
+      updateLineAuthors(_roomLineAttributions);
+      return;
     }
 
     let startLine = lineNumberAtOffset(newValue, prefixLen);
@@ -1456,8 +1492,11 @@ function shiftLineAttributionsByDelta(map, oldText, delta) {
       const deletedLineBreaks = countLineBreaks(deletedSlice);
       if (deletedLineBreaks > 0) {
         const anchorLine = lineNumberAtOffset(baseText, oldCursor);
-        const deletedStartLine = anchorLine + 1;
-        const deletedEndLine = anchorLine + deletedLineBreaks;
+      
+        const deletedStartLine = isOffsetAtLineStart(baseText, oldCursor)
+          ? anchorLine
+          : anchorLine + 1;
+        const deletedEndLine = deletedStartLine + deletedLineBreaks - 1;
         const shifted = shiftLineAttributionsAfterLine(
           working,
           deletedEndLine,
@@ -1794,6 +1833,17 @@ async function getRoomStorageUrl(roomKey) {
   return `${base}rooms/${safeKey}.md`;
 }
 
+async function getRoomLineAttributionStorageUrl(roomKey) {
+  if (!roomKey) return null;
+  if (!hyperdriveUrl) {
+    const roomUrl = await getRoomStorageUrl(roomKey);
+    if (!roomUrl) return null;
+  }
+  const base = hyperdriveUrl.endsWith("/") ? hyperdriveUrl : `${hyperdriveUrl}/`;
+  const safeKey = roomKey.replace(/[^a-z0-9]+/gi, "_");
+  return `${base}rooms/${safeKey}.line-attributions.json`;
+}
+
 async function loadRoomFromHyperdrive(roomKey) {
   try {
     const snapshot = await loadRoomSnapshotFromHyperdrive(roomKey);
@@ -1813,6 +1863,20 @@ async function loadRoomSnapshotFromHyperdrive(roomKey) {
     return { found: true, content: typeof content === "string" ? content : "" };
   } catch {
     return { found: false, content: "" };
+  }
+}
+
+async function loadRoomLineAttributionsFromHyperdrive(roomKey) {
+  try {
+    const url = await getRoomLineAttributionStorageUrl(roomKey);
+    if (!url) return {};
+    const response = await fetchWithTimeout(url, {}, 2000);
+    if (!response.ok) return {};
+    const data = await response.json();
+    const normalized = normalizeLineAttributions(data?.lineAttributions || data);
+    return normalized || {};
+  } catch {
+    return {};
   }
 }
 
@@ -1839,6 +1903,34 @@ async function saveRoomToHyperdrive(roomKey, content) {
     }
   } catch {} finally {
     hyperSaveInFlight = false;
+  }
+}
+
+async function saveRoomLineAttributionsToHyperdrive(roomKey, lineAttributions) {
+  if (lineAttributionHyperSaveInFlight) return;
+  try {
+    const url = await getRoomLineAttributionStorageUrl(roomKey);
+    if (!url) return;
+    const normalized = normalizeLineAttributions(lineAttributions) || {};
+    lineAttributionHyperSaveInFlight = true;
+    const payload = JSON.stringify({
+      roomKey,
+      lineAttributions: normalized,
+      updatedAt: Date.now()
+    });
+    const file = new File([payload], "line-attributions.json", { type: "application/json" });
+    await fetchWithTimeout(
+      url,
+      {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": file.type || "application/json" }
+      },
+      5000
+    );
+  } catch {
+  } finally {
+    lineAttributionHyperSaveInFlight = false;
   }
 }
 
@@ -1990,7 +2082,9 @@ function persistPeerActivitySnapshot() {
 function setPeerList(peerList) {
   currentPeerList = normalizePeerList(peerList);
   // Resolve attribution conflicts deterministically per line.
-  // This removes peer-order dependence in setPeerList() updates.
+  // Imp : peer-list payloads are incremental and can be temporarily
+  // incomplete per client so never replace the whole room map from only the
+  // latest peer snapshot merge winners into the existing room map.
   const winningAttributionsByLine = new Map();
   for (const peer of currentPeerList) {
     if (!peer) continue;
@@ -2029,21 +2123,42 @@ function setPeerList(peerList) {
     }
   }
 
-  const deterministicMergedAttributions = {};
+  const mergedRoomAttributions = normalizeLineAttributions(_roomLineAttributions) || {};
+  let roomChanged = false;
   const sortedWinningLines = Array.from(winningAttributionsByLine.keys()).sort((a, b) => Number(a) - Number(b));
   for (const lineKey of sortedWinningLines) {
     const winner = winningAttributionsByLine.get(lineKey);
-    deterministicMergedAttributions[lineKey] = {
+    const nextValue = {
       name: winner?.name || "",
       color: winner?.color || "",
       clientId: winner?.clientId || "",
       updatedAt: Number.isFinite(Number(winner?.updatedAt)) ? Number(winner.updatedAt) : 0
     };
+    const prevValue = mergedRoomAttributions[lineKey];
+    const shouldReplace =
+      !prevValue ||
+      compareLineAttributionCandidates(nextValue, prevValue) >= 0 ||
+      prevValue.name !== nextValue.name ||
+      prevValue.color !== nextValue.color;
+    if (!shouldReplace) continue;
+    if (
+      !prevValue ||
+      prevValue.name !== nextValue.name ||
+      prevValue.color !== nextValue.color ||
+      (prevValue.clientId || "") !== (nextValue.clientId || "") ||
+      Number(prevValue.updatedAt || 0) !== Number(nextValue.updatedAt || 0)
+    ) {
+      mergedRoomAttributions[lineKey] = nextValue;
+      roomChanged = true;
+    }
   }
-  const roomDiff = diffLineAttributionMaps(_roomLineAttributions, deterministicMergedAttributions);
-  _roomLineAttributions = deterministicMergedAttributions;
-  if (roomDiff.addedCount || roomDiff.removedCount || roomDiff.changedCount) {
-    scheduleRoomLineAttributionsPersist();
+
+  if (roomChanged) {
+    const roomDiff = diffLineAttributionMaps(_roomLineAttributions, mergedRoomAttributions);
+    _roomLineAttributions = mergedRoomAttributions;
+    if (roomDiff.addedCount || roomDiff.removedCount || roomDiff.changedCount) {
+      scheduleRoomLineAttributionsPersist();
+    }
   }
 
   refreshRoomAttributionNamesFromPeerList();
@@ -2262,11 +2377,22 @@ async function connectToRoom(localUrl, role = "client") {
   currentRoomUrl = localUrl;
   currentRole = normalizePeerRole(role || "client");
   hasSyncedLatexModeFromRoom = false;
-  // Keep local ownership map in-memory only for the active session.
-  // Reloading stale line-number ownership from storage can overwrite peer traces after reconnect.
-  _localLineAttributions = {};
+  const cachedRoomLineAttributions = readRoomLineAttributions(currentRoomKey);
+  let restoredRoomLineAttributions = cachedRoomLineAttributions;
+  if (
+    currentRoomKey &&
+    (!restoredRoomLineAttributions || Object.keys(restoredRoomLineAttributions).length === 0)
+  ) {
+    const remoteLineAttributions = await loadRoomLineAttributionsFromHyperdrive(currentRoomKey);
+    if (remoteLineAttributions && Object.keys(remoteLineAttributions).length > 0) {
+      restoredRoomLineAttributions = remoteLineAttributions;
+    }
+  }
+  _roomLineAttributions = restoredRoomLineAttributions || {};
+
+  _localLineAttributions = filterLineAttributionsByClientId(_roomLineAttributions, localClientId);
   clearLocalLineAttributions(currentRoomKey);
-  _roomLineAttributions = readRoomLineAttributions(currentRoomKey);
+  persistRoomLineAttributionsNow();
   updateLineAuthors(_roomLineAttributions);
   currentPeerList = [];
   peerActivityLog = [];


### PR DESCRIPTION
## Issue 

Gutter line ownership could become inconsistent across peers in collaborative editing, especially during:
- concurrent inserts/deletes near the top of the document
- reconnect/restart flows
- transient/incomplete peer-list snapshots

This caused cases where one peer showed different ownership marks than others even when text content had converged.

## Changes

- Stabilized line-attribution shifting for delete operations that begin at line boundaries.
- Avoided accidental ownership takeover on pure line-removal deletes by preserving shifted ownership instead of re-attributing surviving lines.
- Changed peer-list attribution handling from full-map replacement to deterministic merge into existing room attribution state to prevent snapshot-race overwrites.
- Added URL-state boolean parsing/handling for room state flags (`hosted`, `creator`) to preserve host/client intent reliably across restart.
- Added Hyperdrive-backed persistence for room line-attribution snapshots (`*.line-attributions.json`) and load-on-connect fallback for better restart durability.
- Rebuilt local attribution map from restored room map on reconnect so ownership presence can republish immediately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Manual multi-instance verification (3 peers) for:
  - distributed inserts
  - delete-from-top behavior
  - whitespace churn scenarios
  - restart/reconnect behavior and gutter restoration
- Automated E2E validation in downstream integration harness:
  - `npm run test:p2pmd:gutter:e2e`
  - Verified content convergence and cross-peer ownership consistency.

## Checklist

- [x] My code follows the contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented code where needed for clarity.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.