### PR TITLE
perf: stop preview, gutter and pagination scaling with document length

### DIFF
--- a/cursorOverlay.js
+++ b/cursorOverlay.js
@@ -1,5 +1,11 @@
 /**
  * Renders authorship marks and live peer cursors over the textarea.
+ *
+ * Caret positions come from a hidden mirror of the textarea. Every input and
+ * scroll schedules a redraw, so the mirror is written once per redraw and all
+ * positions read back without touching it in between - one layout instead of
+ * one per mark. Coordinates are cached per document text, so scrolling costs
+ * no measuring at all.
  */
 let _textarea = null;
 let _localClientId = null;
@@ -7,11 +13,21 @@ let _gutterEl = null;
 let _authorGutterEl = null;
 let _overlayEl = null;
 let _mirrorEl = null;
+let _mirrorTextNode = null;
+let _measureRange = null;
 let _rafId = null;
 let _peers = [];
 let _resizeObserver = null;
 let _lineAuthors = {};
 const PEER_NAME_TRUNCATE_LEN = 8;
+const MIRROR_TAIL = "\u200b";
+
+/* Measurement caches, keyed on the text they came from. */
+let _cacheText = null;
+let _cacheStyleKey = "";
+let _cacheCoords = new Map();
+let _cacheLineStarts = null;
+let _cacheLineStartsText = null;
 
 function _onScroll() { _scheduleUpdate(); }
 function _onInput() { _scheduleUpdate(); }
@@ -31,7 +47,11 @@ export function initCursorOverlay(textareaEl, localClientId) {
   _mirrorEl.style.cssText =
     "position:fixed;top:-9999px;left:-9999px;visibility:hidden;" +
     "white-space:pre-wrap;word-wrap:break-word;overflow-wrap:break-word;overflow:hidden;";
+  _mirrorTextNode = document.createTextNode("");
+  _mirrorEl.appendChild(_mirrorTextNode);
   document.body.appendChild(_mirrorEl);
+  _measureRange = document.createRange();
+  _invalidateMeasureCache();
 
   _textarea.addEventListener("scroll", _onScroll, { passive: true });
   _textarea.addEventListener("input", _onInput, { passive: true });
@@ -72,6 +92,9 @@ export function destroyCursorOverlay() {
   if (_overlayEl) { _overlayEl.remove(); _overlayEl = null; }
   if (_mirrorEl) { _mirrorEl.remove(); _mirrorEl = null; }
 
+  _mirrorTextNode = null;
+  _measureRange = null;
+  _invalidateMeasureCache();
   _textarea = null;
   _localClientId = null;
   _peers = [];
@@ -86,133 +109,31 @@ function _scheduleUpdate() {
   });
 }
 
-function _redraw() {
-  if (!_textarea) return;
-  _syncMirror();
-  _renderAuthorshipGutter();
-  _renderLiveCursors();
+function _invalidateMeasureCache() {
+  _cacheText = null;
+  _cacheStyleKey = "";
+  _cacheCoords = new Map();
+  _cacheLineStarts = null;
+  _cacheLineStartsText = null;
 }
 
-function _renderAuthorshipGutter() {
-  if (!_authorGutterEl) return;
-  _authorGutterEl.innerHTML = "";
-
-  const text = _textarea.value || "";
-  const scrollTop = _textarea.scrollTop;
-  const totalLines = (text.match(/\n/g) || []).length + 1;
-  const entries = Object.entries(_lineAuthors)
-    .map(([lineStr, info]) => ({ line: parseInt(lineStr, 10), info }))
-    .filter((entry) => Number.isFinite(entry.line) && entry.line >= 1 && entry.info?.color)
-    .sort((a, b) => a.line - b.line);
-
-  for (let i = 0; i < entries.length; i += 1) {
-    const current = entries[i];
-    const next = entries[i + 1];
-    const startLine = current.line;
-    const endLine = Math.min(totalLines, Math.max(startLine, next ? next.line - 1 : totalLines));
-    if (startLine > totalLines || endLine < startLine) continue;
-
-    const startOffset = _lineToOffset(text, startLine);
-    const endOffset = _lineToOffset(text, endLine + 1);
-    const startCoords = _getCaretCoords(text, startOffset);
-    const endCoords = endOffset > startOffset ? _getCaretCoords(text, endOffset) : null;
-    if (!startCoords) continue;
-
-    const lineHeight = endCoords
-      ? Math.max(startCoords.lh, endCoords.top - startCoords.top)
-      : startCoords.lh;
-    const top = startCoords.top - scrollTop;
-    if (top + lineHeight < 0 || top > _textarea.clientHeight + startCoords.lh) continue;
-
-    const name = _resolveAuthorName(current.info);
-    const mark = document.createElement("div");
-    mark.className = "author-gutter-mark";
-    mark.style.cssText = `top:${top}px;height:${lineHeight}px;background:${current.info.color};--peer-color:${current.info.color};`;
-    mark.dataset.peerName = name;
-    mark.title = name;
-    _authorGutterEl.appendChild(mark);
+/* Offsets at which each 1-based line begins; index 0 holds line 1. */
+function _lineStarts(text) {
+  if (_cacheLineStartsText === text && _cacheLineStarts) return _cacheLineStarts;
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text.charCodeAt(i) === 10) starts.push(i + 1);
   }
-}
-
-function _renderLiveCursors() {
-  if (!_gutterEl || !_overlayEl) return;
-  _gutterEl.innerHTML = "";
-  _overlayEl.innerHTML = "";
-
-  const text = _textarea.value || "";
-  const scrollTop = _textarea.scrollTop;
-  const remote = _peers.filter((p) =>
-    p && p.clientId && p.clientId !== _localClientId &&
-    typeof p.cursorLine === "number" && p.cursorLine > 0
-  );
-
-  for (const peer of remote) {
-    const coords = _getCaretCoords(
-      text,
-      _lineColumnToOffset(text, peer.cursorLine, peer.cursorColumn)
-    );
-    if (!coords) continue;
-
-    const top = coords.top - scrollTop;
-    const color = peer.color || _hsl(peer.clientId);
-    const name = peer.name || _trunc(peer.clientId, PEER_NAME_TRUNCATE_LEN);
-    const idle = peer.isTyping === false;
-    if (top < -coords.lh || top > _textarea.clientHeight + coords.lh) continue;
-
-    const chip = document.createElement("div");
-    chip.className = idle ? "peer-cursor-chip idle" : "peer-cursor-chip";
-    chip.style.cssText =
-      `top:${top}px;left:${Math.max(0, coords.left - _textarea.scrollLeft - 4)}px;` +
-      `height:${coords.lh}px;--peer-color:${color};`;
-    chip.dataset.peerName = name;
-    chip.title = name;
-    _overlayEl.appendChild(chip);
-  }
-}
-
-function _syncMirror() {
-  if (!_textarea || !_mirrorEl) return;
-  const cs = window.getComputedStyle(_textarea);
-  const copy = [
-    "font-family", "font-size", "font-weight", "font-style", "letter-spacing",
-    "line-height", "text-indent", "text-transform", "word-spacing",
-    "padding-top", "padding-right", "padding-bottom", "padding-left",
-    "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
-    "box-sizing"
-  ].map((p) => `${p}:${cs.getPropertyValue(p)}`).join(";");
-  _mirrorEl.style.cssText =
-    "position:fixed;top:-9999px;left:-9999px;visibility:hidden;" +
-    "white-space:pre-wrap;word-wrap:break-word;overflow-wrap:break-word;overflow:hidden;" +
-    `width:${_textarea.clientWidth}px;${copy}`;
-}
-
-/* Returns coordinates relative to textarea top-left. */
-function _getCaretCoords(text, offset) {
-  if (!_mirrorEl) return null;
-  const safe = Math.max(0, Math.min(Number.isFinite(offset) ? offset : 0, text.length));
-
-  _mirrorEl.textContent = "";
-  _mirrorEl.appendChild(document.createTextNode(text.slice(0, safe)));
-  const span = document.createElement("span");
-  span.textContent = text[safe] || "\u200b";
-  _mirrorEl.appendChild(span);
-  _mirrorEl.appendChild(document.createTextNode(text.slice(safe + 1)));
-
-  const sr = span.getBoundingClientRect();
-  const mr = _mirrorEl.getBoundingClientRect();
-  const cs = window.getComputedStyle(_textarea);
-  const lh = parseFloat(cs.lineHeight) || 20;
-
-  return { top: sr.top - mr.top, left: sr.left - mr.left, lh };
+  _cacheLineStarts = starts;
+  _cacheLineStartsText = text;
+  return starts;
 }
 
 function _lineToOffset(text, line) {
-  if (!text || line <= 1) return 0;
-  let n = 1;
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === "\n" && ++n === line) return i + 1;
-  }
-  return text.length;
+  const starts = _lineStarts(text);
+  if (line <= 1) return 0;
+  if (line > starts.length) return text.length;
+  return starts[line - 1];
 }
 
 /* 1-based line+column to char offset. */
@@ -224,6 +145,204 @@ function _lineColumnToOffset(text, line, column) {
   const maxCharsOnLine = Math.max(0, lineEndExclusive - lineStart);
   const colIndex = Math.max(0, Math.min(maxCharsOnLine, Math.floor(Number(column)) - 1));
   return lineStart + colIndex;
+}
+
+/* Copies the textarea's text metrics onto the mirror. The returned key changes
+   whenever something that affects wrapping does. */
+function _syncMirror() {
+  const cs = window.getComputedStyle(_textarea);
+  const copy = [
+    "font-family", "font-size", "font-weight", "font-style", "letter-spacing",
+    "line-height", "text-indent", "text-transform", "word-spacing",
+    "padding-top", "padding-right", "padding-bottom", "padding-left",
+    "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
+    "box-sizing"
+  ].map((p) => `${p}:${cs.getPropertyValue(p)}`).join(";");
+  const styleKey = `${_textarea.clientWidth}|${copy}`;
+  if (styleKey !== _cacheStyleKey) {
+    _mirrorEl.style.cssText =
+      "position:fixed;top:-9999px;left:-9999px;visibility:hidden;" +
+      "white-space:pre-wrap;word-wrap:break-word;overflow-wrap:break-word;overflow:hidden;" +
+      `width:${_textarea.clientWidth}px;${copy}`;
+    _cacheStyleKey = styleKey;
+    _cacheCoords.clear();
+  }
+  return { styleKey, lineHeight: parseFloat(cs.lineHeight) || 20 };
+}
+
+/* Coordinates for every requested offset, relative to the mirror's top-left.
+   One Range, reused, with no writes in between - so one layout however many
+   offsets are asked for. */
+function _measureOffsets(text, offsets) {
+  const result = new Map();
+  if (!_mirrorEl || !_mirrorTextNode || !_measureRange) return result;
+
+  const pending = [];
+  for (const offset of offsets) {
+    if (_cacheText === text && _cacheCoords.has(offset)) {
+      result.set(offset, _cacheCoords.get(offset));
+    } else {
+      pending.push(offset);
+    }
+  }
+  if (pending.length === 0) return result;
+
+  if (_cacheText !== text) {
+    // Tail sentinel: gives end-of-document something to measure.
+    _mirrorTextNode.nodeValue = `${text}${MIRROR_TAIL}`;
+    _cacheText = text;
+    _cacheCoords.clear();
+  }
+
+  const mirrorRect = _mirrorEl.getBoundingClientRect();
+  const mirrorLength = _mirrorTextNode.nodeValue.length;
+  for (const offset of pending) {
+    const safe = Math.max(0, Math.min(offset, text.length));
+    if (safe >= mirrorLength) continue;
+    let rect = null;
+    try {
+      _measureRange.setStart(_mirrorTextNode, safe);
+      _measureRange.setEnd(_mirrorTextNode, safe + 1);
+      rect = _measureRange.getBoundingClientRect();
+      // A range over a line break collapses to nothing, but the rect list
+      // still knows where the break is.
+      if (rect.height === 0 && rect.width === 0) {
+        const rects = _measureRange.getClientRects();
+        if (rects.length > 0) rect = rects[0];
+      }
+    } catch {
+      rect = null;
+    }
+    if (!rect) continue;
+    const coords = { top: rect.top - mirrorRect.top, left: rect.left - mirrorRect.left };
+    _cacheCoords.set(offset, coords);
+    result.set(offset, coords);
+  }
+  return result;
+}
+
+function _redraw() {
+  if (!_textarea || !_authorGutterEl || !_gutterEl || !_overlayEl) return;
+  // Hidden editor: nothing to measure, and the numbers would be stale anyway.
+  // The ResizeObserver redraws once it is back.
+  if (_textarea.offsetParent === null && _textarea.clientWidth === 0) return;
+
+  const text = _textarea.value || "";
+  const gutterEntries = _collectAuthorEntries(text);
+  const cursorEntries = _collectCursorEntries(text);
+
+  if (gutterEntries.length === 0 && cursorEntries.length === 0) {
+    _authorGutterEl.replaceChildren();
+    _gutterEl.replaceChildren();
+    _overlayEl.replaceChildren();
+    return;
+  }
+
+  const { lineHeight } = _syncMirror();
+
+  const offsets = new Set();
+  for (const entry of gutterEntries) {
+    offsets.add(entry.startOffset);
+    offsets.add(entry.endOffset);
+  }
+  for (const entry of cursorEntries) offsets.add(entry.offset);
+
+  const coords = _measureOffsets(text, offsets);
+  _renderAuthorshipGutter(gutterEntries, coords, lineHeight);
+  _renderLiveCursors(cursorEntries, coords, lineHeight);
+}
+
+function _collectAuthorEntries(text) {
+  const entries = [];
+  const lineAuthors = _lineAuthors;
+  for (const lineStr of Object.keys(lineAuthors)) {
+    const line = parseInt(lineStr, 10);
+    const info = lineAuthors[lineStr];
+    if (!Number.isFinite(line) || line < 1 || !info?.color) continue;
+    entries.push({ line, info });
+  }
+  if (entries.length === 0) return entries;
+  entries.sort((a, b) => a.line - b.line);
+
+  const totalLines = _lineStarts(text).length;
+  const spans = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const current = entries[i];
+    const next = entries[i + 1];
+    const startLine = current.line;
+    const endLine = Math.min(totalLines, Math.max(startLine, next ? next.line - 1 : totalLines));
+    if (startLine > totalLines || endLine < startLine) continue;
+    const startOffset = _lineToOffset(text, startLine);
+    const endOffset = _lineToOffset(text, endLine + 1);
+    spans.push({ info: current.info, startOffset, endOffset });
+  }
+  return spans;
+}
+
+function _collectCursorEntries(text) {
+  const entries = [];
+  for (const peer of _peers) {
+    if (!peer || !peer.clientId || peer.clientId === _localClientId) continue;
+    if (typeof peer.cursorLine !== "number" || peer.cursorLine <= 0) continue;
+    entries.push({ peer, offset: _lineColumnToOffset(text, peer.cursorLine, peer.cursorColumn) });
+  }
+  return entries;
+}
+
+function _renderAuthorshipGutter(spans, coords, defaultLineHeight) {
+  const scrollTop = _textarea.scrollTop;
+  const viewportHeight = _textarea.clientHeight;
+  const fragment = document.createDocumentFragment();
+
+  for (const span of spans) {
+    const startCoords = coords.get(span.startOffset);
+    if (!startCoords) continue;
+    const endCoords = span.endOffset > span.startOffset ? coords.get(span.endOffset) : null;
+    const lineHeight = endCoords
+      ? Math.max(defaultLineHeight, endCoords.top - startCoords.top)
+      : defaultLineHeight;
+    const top = startCoords.top - scrollTop;
+    if (top + lineHeight < 0 || top > viewportHeight + defaultLineHeight) continue;
+
+    const name = _resolveAuthorName(span.info);
+    const mark = document.createElement("div");
+    mark.className = "author-gutter-mark";
+    mark.style.cssText = `top:${top}px;height:${lineHeight}px;background:${span.info.color};--peer-color:${span.info.color};`;
+    mark.dataset.peerName = name;
+    mark.title = name;
+    fragment.appendChild(mark);
+  }
+  _authorGutterEl.replaceChildren(fragment);
+}
+
+function _renderLiveCursors(entries, coords, defaultLineHeight) {
+  const scrollTop = _textarea.scrollTop;
+  const scrollLeft = _textarea.scrollLeft;
+  const viewportHeight = _textarea.clientHeight;
+  const fragment = document.createDocumentFragment();
+
+  for (const { peer, offset } of entries) {
+    const position = coords.get(offset);
+    if (!position) continue;
+
+    const top = position.top - scrollTop;
+    if (top < -defaultLineHeight || top > viewportHeight + defaultLineHeight) continue;
+
+    const color = peer.color || _hsl(peer.clientId);
+    const name = peer.name || _trunc(peer.clientId, PEER_NAME_TRUNCATE_LEN);
+    const idle = peer.isTyping === false;
+
+    const chip = document.createElement("div");
+    chip.className = idle ? "peer-cursor-chip idle" : "peer-cursor-chip";
+    chip.style.cssText =
+      `top:${top}px;left:${Math.max(0, position.left - scrollLeft - 4)}px;` +
+      `height:${defaultLineHeight}px;--peer-color:${color};`;
+    chip.dataset.peerName = name;
+    chip.title = name;
+    fragment.appendChild(chip);
+  }
+  _gutterEl.replaceChildren();
+  _overlayEl.replaceChildren(fragment);
 }
 
 function _trunc(s, n) {

--- a/noteEditor.js
+++ b/noteEditor.js
@@ -1,4 +1,4 @@
-﻿import { markdownInput, markdownPreview, slidesPreview, viewSlidesButton, fullPreviewButton, loadingSpinner, backdrop } from "./common.js";
+import { markdownInput, markdownPreview, slidesPreview, viewSlidesButton, fullPreviewButton, loadingSpinner, backdrop } from "./common.js";
 
 let md = null;
 let renderTimer = null;
@@ -10,6 +10,25 @@ const IEEE_PREVIEW_LARGE_SCALE = 1;
 const IEEE_PREVIEW_MIN_SCALE = 0.55;
 const IEEE_PREVIEW_SCALE_SAFETY = 0.985;
 const IEEE_PREVIEW_VISUAL_GAP_PX = 10;
+
+const RENDER_DEBOUNCE_MS = 120;
+const RENDER_DEBOUNCE_SLOW_MS = 300;
+const RENDER_SLOW_THRESHOLD_MS = 60;
+// Repagination measures every block, so it waits for a typing pause and then
+// runs in short slices instead of blocking the editor.
+const IEEE_REPAGINATE_IDLE_MS = 220;
+const IEEE_REPAGINATE_FAST_LIMIT_MS = 40;
+const IEEE_PAGINATE_SLICE_MS = 10;
+// Wrapper that keeps staged pages in the document but out of sight. The height
+// cap belongs here, not on the stack: the stack is a column flex box, and
+// capping it would squash the very pages being measured.
+const IEEE_STAGING_STYLE = "height:0;overflow:hidden;visibility:hidden;pointer-events:none;";
+// Backstop, so a block that somehow never fits can't spin forever.
+const IEEE_MAX_PAGES = 2000;
+const SLIDE_MARKER_RE = /^---$|^<!-- slide -->$/m;
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+
+let lastRenderDurationMs = 0;
 
 function scheduleIeeeRepaginationFromResize() {
   if (ieeeResizeRenderTimer) clearTimeout(ieeeResizeRenderTimer);
@@ -81,10 +100,15 @@ export function initMarkdown() {
       return defaultRender(tokens, idx, options, env, self);
     };
 
+    resetIncrementalPreview();
     renderPreview();
     if (!ieeeResizeBound) {
       window.addEventListener("resize", scheduleIeeeRepaginationFromResize);
       ieeeResizeBound = true;
+    }
+    if (!scrollSyncBound) {
+      markdownInput.addEventListener("scroll", requestScrollSync, { passive: true });
+      scrollSyncBound = true;
     }
   } catch {
     md = null;
@@ -92,10 +116,356 @@ export function initMarkdown() {
   }
 }
 
+function stripHtmlComments(markdown) {
+  return (markdown || "").replace(HTML_COMMENT_RE, "");
+}
+
 export function renderMarkdown(markdown) {
   if (!md) return markdown || "";
-  const cleanedMarkdown = (markdown || "").replace(/<!--[\s\S]*?-->/g, "");
-  return md.render(cleanedMarkdown);
+  return md.render(stripHtmlComments(markdown));
+}
+
+/* Incremental preview rendering.
+ *
+ * Re-rendering the whole document per keystroke means a full markdown pass, a
+ * full KaTeX pass and a full DOM rebuild - hundreds of ms once the document
+ * grows. So: split the tokens into top-level blocks, cache each block's HTML
+ * under its own source, and only re-render and patch the ones that changed.
+ * An edit usually touches one block, so cost stops tracking document length. */
+
+// Rendered HTML for the current document's blocks, keyed by block source.
+let blockHtmlCache = new Map();
+// Blocks currently in the DOM: { key, nodes, startLine, endLine }, in order.
+let previewBlocks = [];
+let previewNeedsFullRender = true;
+let lastPreviewSource = null;
+
+function resetIncrementalPreview() {
+  previewBlocks = [];
+  previewNeedsFullRender = true;
+  lastPreviewSource = null;
+}
+
+/* Splits a flat token stream into top-level blocks. */
+function groupTopLevelTokens(tokens) {
+  const groups = [];
+  let current = null;
+  let depth = 0;
+
+  for (const token of tokens) {
+    if (!current) current = [];
+    current.push(token);
+    depth += token.nesting;
+    if (depth <= 0) {
+      groups.push(current);
+      current = null;
+      depth = 0;
+    }
+  }
+  if (current) groups.push(current);
+  return groups;
+}
+
+/* A block's HTML depends on its own source plus the document's link reference
+   definitions, so both go in the key. Blocks with no source map fall back to a
+   signature off their tokens - slower to build, but never wrong. */
+function blockCacheKey(group, srcLines, envKey) {
+  const first = group[0];
+  const map = first?.map;
+  if (Array.isArray(map) && Number.isInteger(map[0]) && Number.isInteger(map[1]) && map[1] > map[0]) {
+    return `${envKey}\u0000${srcLines.slice(map[0], map[1]).join("\n")}`;
+  }
+  let signature = `${envKey}\u0000nomap`;
+  for (const token of group) {
+    signature += `\u0000${token.type}|${token.tag}|${token.markup}|${token.info}|${token.content}`;
+  }
+  return signature;
+}
+
+function htmlToNodes(html) {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  const nodes = [];
+  for (const node of Array.from(template.content.childNodes)) {
+    // markdown-it separates blocks with newlines; they render as nothing and
+    // only complicate the node bookkeeping.
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.trim().length === 0) continue;
+    nodes.push(node);
+  }
+  return nodes;
+}
+
+/* True when the DOM still holds exactly what we last rendered. Anything else
+   (slides, IEEE pages, outside writes) means rebuild from scratch. */
+function previewDomMatchesBlocks() {
+  let expected = 0;
+  for (const block of previewBlocks) {
+    for (const node of block.nodes) {
+      if (node.parentNode !== markdownPreview) return false;
+      expected += 1;
+    }
+  }
+  return markdownPreview.childNodes.length === expected;
+}
+
+function renderPreviewIncremental(markdown) {
+  // Plenty of callers re-render without the text having changed (mode toggles,
+  // peer updates, reconnects). Nothing to do for those.
+  if (!previewNeedsFullRender && lastPreviewSource === markdown && previewDomMatchesBlocks()) {
+    return;
+  }
+
+  const src = stripHtmlComments(markdown);
+  const env = {};
+  const tokens = md.parse(src, env);
+  const envKey = env.references ? JSON.stringify(env.references) : "";
+  const srcLines = src.split("\n");
+  const groups = groupTopLevelTokens(tokens);
+
+  const nextCache = new Map();
+  let lineCursor = 0;
+  const nextBlocks = groups.map((group) => {
+    const key = blockCacheKey(group, srcLines, envKey);
+    let html = nextCache.get(key);
+    if (html === undefined) {
+      html = blockHtmlCache.get(key);
+      if (html === undefined) html = md.renderer.render(group, md.options, env);
+      nextCache.set(key, html);
+    }
+    // Source line range, for lining the preview up with the editor.
+    const map = group[0]?.map;
+    const startLine = Array.isArray(map) ? map[0] : lineCursor;
+    const endLine = Array.isArray(map) ? map[1] : startLine + 1;
+    lineCursor = endLine;
+    return { key, html, nodes: null, startLine, endLine };
+  });
+  blockHtmlCache = nextCache;
+
+  if (previewNeedsFullRender || !previewDomMatchesBlocks()) {
+    const fragment = document.createDocumentFragment();
+    for (const block of nextBlocks) {
+      block.nodes = htmlToNodes(block.html);
+      for (const node of block.nodes) fragment.appendChild(node);
+    }
+    markdownPreview.replaceChildren(fragment);
+  } else {
+    patchPreviewBlocks(nextBlocks);
+  }
+
+  previewBlocks = nextBlocks.map((block) => ({
+    key: block.key,
+    nodes: block.nodes || [],
+    startLine: block.startLine,
+    endLine: block.endLine
+  }));
+  previewNeedsFullRender = false;
+  lastPreviewSource = markdown;
+}
+
+/* Replaces only the run of blocks between the unchanged head and tail. */
+function patchPreviewBlocks(nextBlocks) {
+  const oldBlocks = previewBlocks;
+  const oldLen = oldBlocks.length;
+  const newLen = nextBlocks.length;
+
+  let head = 0;
+  while (head < oldLen && head < newLen && oldBlocks[head].key === nextBlocks[head].key) head += 1;
+
+  let tail = 0;
+  while (
+    tail < oldLen - head &&
+    tail < newLen - head &&
+    oldBlocks[oldLen - 1 - tail].key === nextBlocks[newLen - 1 - tail].key
+  ) {
+    tail += 1;
+  }
+
+  for (let i = 0; i < head; i += 1) nextBlocks[i].nodes = oldBlocks[i].nodes;
+  for (let i = 0; i < tail; i += 1) nextBlocks[newLen - 1 - i].nodes = oldBlocks[oldLen - 1 - i].nodes;
+
+  let anchor = null;
+  for (let i = oldLen - tail; i < oldLen && !anchor; i += 1) {
+    anchor = oldBlocks[i].nodes[0] || null;
+  }
+
+  for (let i = head; i < oldLen - tail; i += 1) {
+    for (const node of oldBlocks[i].nodes) node.remove();
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (let i = head; i < newLen - tail; i += 1) {
+    nextBlocks[i].nodes = htmlToNodes(nextBlocks[i].html);
+    for (const node of nextBlocks[i].nodes) fragment.appendChild(node);
+  }
+  if (fragment.childNodes.length > 0) markdownPreview.insertBefore(fragment, anchor);
+}
+
+/* Scroll sync.
+ *
+ * The preview follows the editor: whatever line sits at the top of the
+ * textarea, the matching block sits at the top of the preview. Finding that
+ * line needs the editor's wrapped line positions, which only the browser
+ * knows, so they are measured in a hidden copy of the textarea - binary
+ * search, so a handful of reads whatever the document length. Paginated and
+ * slide views have no line map, so those fall back to plain proportion. */
+const SYNC_MIRROR_BASE_STYLE =
+  "position:fixed;top:-9999px;left:-9999px;visibility:hidden;" +
+  "white-space:pre-wrap;word-wrap:break-word;overflow-wrap:break-word;overflow:hidden;";
+const SYNC_MIRROR_PROPS = [
+  "font-family", "font-size", "font-weight", "font-style", "letter-spacing",
+  "line-height", "text-indent", "text-transform", "word-spacing",
+  "padding-top", "padding-right", "padding-bottom", "padding-left",
+  "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
+  "box-sizing"
+];
+
+let scrollSyncBound = false;
+let scrollSyncFrame = null;
+let syncMirrorEl = null;
+let syncMirrorTextNode = null;
+let syncRange = null;
+let syncMirrorText = null;
+let syncMirrorStyleKey = "";
+let syncLineStarts = null;
+let syncLineStartsText = null;
+
+function requestScrollSync() {
+  if (scrollSyncFrame !== null) return;
+  scrollSyncFrame = requestAnimationFrame(() => {
+    scrollSyncFrame = null;
+    syncPreviewToEditor();
+  });
+}
+
+function prepareSyncMirror(text) {
+  if (!syncMirrorEl) {
+    syncMirrorEl = document.createElement("div");
+    syncMirrorEl.setAttribute("aria-hidden", "true");
+    syncMirrorTextNode = document.createTextNode("");
+    syncMirrorEl.appendChild(syncMirrorTextNode);
+    document.body.appendChild(syncMirrorEl);
+    syncRange = document.createRange();
+    syncMirrorText = null;
+    syncMirrorStyleKey = "";
+  }
+
+  const cs = window.getComputedStyle(markdownInput);
+  const copy = SYNC_MIRROR_PROPS.map((p) => `${p}:${cs.getPropertyValue(p)}`).join(";");
+  const styleKey = `${markdownInput.clientWidth}|${copy}`;
+  if (styleKey !== syncMirrorStyleKey) {
+    syncMirrorEl.style.cssText = `${SYNC_MIRROR_BASE_STYLE}width:${markdownInput.clientWidth}px;${copy}`;
+    syncMirrorStyleKey = styleKey;
+  }
+  if (syncMirrorText !== text) {
+    syncMirrorTextNode.nodeValue = `${text}\u200b`;
+    syncMirrorText = text;
+  }
+}
+
+function syncLineStartsFor(text) {
+  if (syncLineStartsText === text && syncLineStarts) return syncLineStarts;
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text.charCodeAt(i) === 10) starts.push(i + 1);
+  }
+  syncLineStarts = starts;
+  syncLineStartsText = text;
+  return starts;
+}
+
+/* Top of a character offset, in the mirror's own coordinates. */
+function offsetTopInMirror(offset) {
+  syncRange.setStart(syncMirrorTextNode, offset);
+  syncRange.setEnd(syncMirrorTextNode, offset + 1);
+  let rect = syncRange.getBoundingClientRect();
+  if (rect.height === 0 && rect.width === 0) {
+    const rects = syncRange.getClientRects();
+    if (rects.length > 0) rect = rects[0];
+  }
+  return rect.top;
+}
+
+/* Which source line the editor has scrolled to, plus how far into it. */
+function editorTopLine(text) {
+  const starts = syncLineStartsFor(text);
+  if (starts.length < 2) return { line: 0, fraction: 0 };
+
+  const firstTop = offsetTopInMirror(0);
+  const target = markdownInput.scrollTop;
+  const topOf = (line) => offsetTopInMirror(starts[line]) - firstTop;
+
+  let low = 0;
+  let high = starts.length - 1;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (topOf(mid) <= target) low = mid;
+    else high = mid - 1;
+  }
+
+  const lineTop = topOf(low);
+  const nextTop = low + 1 < starts.length ? topOf(low + 1) : lineTop;
+  const height = nextTop - lineTop;
+  const fraction = height > 0 ? Math.min(1, Math.max(0, (target - lineTop) / height)) : 0;
+  return { line: low, fraction };
+}
+
+function blockTopInPreview(block, previewTop) {
+  const node = block.nodes.find((n) => n.nodeType === Node.ELEMENT_NODE);
+  if (!node) return null;
+  return node.getBoundingClientRect().top - previewTop + markdownPreview.scrollTop;
+}
+
+function syncPreviewProportionally() {
+  const editorRange = markdownInput.scrollHeight - markdownInput.clientHeight;
+  const previewRange = markdownPreview.scrollHeight - markdownPreview.clientHeight;
+  if (editorRange <= 0 || previewRange <= 0) return;
+  markdownPreview.scrollTop = (markdownInput.scrollTop / editorRange) * previewRange;
+}
+
+function syncPreviewToEditor() {
+  if (!markdownPreview.clientHeight || markdownPreview.classList.contains("hidden")) return;
+  if (markdownPreview.scrollHeight - markdownPreview.clientHeight <= 0) return;
+
+  // Pages and slides carry no line map; proportion is the best available.
+  if (previewBlocks.length === 0 || markdownPreview.classList.contains("markdown-preview--ieee")) {
+    syncPreviewProportionally();
+    return;
+  }
+
+  const text = markdownInput.value || "";
+  let target = null;
+  try {
+    prepareSyncMirror(text);
+    const { line, fraction } = editorTopLine(text);
+
+    let low = 0;
+    let high = previewBlocks.length - 1;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      if (previewBlocks[mid].startLine <= line) low = mid;
+      else high = mid - 1;
+    }
+
+    const block = previewBlocks[low];
+    const previewTop = markdownPreview.getBoundingClientRect().top;
+    const blockTop = blockTopInPreview(block, previewTop);
+    if (blockTop !== null) {
+      const next = previewBlocks[low + 1];
+      const nextTop = next ? blockTopInPreview(next, previewTop) : markdownPreview.scrollHeight;
+      const span = Math.max(1, block.endLine - block.startLine);
+      const into = Math.min(1, Math.max(0, (line - block.startLine + fraction) / span));
+      target = blockTop + ((nextTop ?? blockTop) - blockTop) * into;
+    }
+  } catch {
+    target = null;
+  }
+
+  if (target === null) {
+    syncPreviewProportionally();
+    return;
+  }
+  const max = markdownPreview.scrollHeight - markdownPreview.clientHeight;
+  markdownPreview.scrollTop = Math.min(max, Math.max(0, target));
 }
 
 function isHeadingNode(node) {
@@ -465,11 +835,10 @@ function hasPageOverflow(pageInnerEl, columnsEl, appendedNode) {
   tailProbe.style.fontSize = "0";
   tailProbe.textContent = "\u200b";
   columnsEl.appendChild(tailProbe);
+
+  // All reads happen before the probe is removed, so this costs one layout
+  // per call instead of two.
   const probeRect = tailProbe.getBoundingClientRect();
-  tailProbe.remove();
-
-  const overflowByProbe = probeRect.bottom > colsRect.bottom + 0.5 || probeRect.right > colsRect.right + 0.5;
-
   const overflowByInnerHeight = pageInnerEl.scrollHeight - pageInnerEl.clientHeight > 1;
   const overflowByColumnHeight = columnsEl.scrollHeight - columnsEl.clientHeight > 1;
   const overflowByColumns = columnsEl.scrollWidth - columnsEl.clientWidth > 1;
@@ -484,34 +853,76 @@ function hasPageOverflow(pageInnerEl, columnsEl, appendedNode) {
     }
   }
 
+  const overflowByProbe = probeRect.bottom > colsRect.bottom + 0.5 || probeRect.right > colsRect.right + 0.5;
+  tailProbe.remove();
+
   return overflowByProbe || overflowByInnerHeight || overflowByColumnHeight || overflowByColumns || overflowByGeometry;
 }
 
-function paginateIeeePreview() {
-  const layout = markdownPreview.querySelector(".ieee-paper-layout");
-  if (!layout) return 0;
+/* IEEE pagination.
+ *
+ * Placing a block needs a layout read, so a long paper is expensive no matter
+ * what. Run it in short slices that yield in between, and give every run a
+ * token so a newer edit or resize drops the old one instead of queueing. */
+let ieeeRunToken = 0;
+let ieeeRepaginateTimer = null;
+let ieeeHtmlCacheSource = null;
+let ieeeHtmlCacheValue = "";
+let ieeeFontsWatched = false;
+let lastPaginateDurationMs = 0;
+
+/* Gives the event loop back between slices so typing stays responsive. Not
+   rAF: frame callbacks stop in a hidden window, which would strand a
+   half-paginated preview until it came back. */
+function yieldToEventLoop() {
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      resolve();
+    };
+    channel.port2.postMessage(0);
+  });
+}
+
+function getIeeeLayoutHtml(markdown) {
+  const source = markdown || "";
+  if (ieeeHtmlCacheSource === source) return ieeeHtmlCacheValue;
+  const html = renderDocument(source, { ieeeLayout: true });
+  ieeeHtmlCacheSource = source;
+  ieeeHtmlCacheValue = html;
+  return html;
+}
+
+async function paginateIeeePreview(runToken, layout, stack) {
+  if (!layout) return false;
 
   const frontmatter = layout.querySelector(":scope > .ieee-frontmatter");
   const columns = layout.querySelector(":scope > .ieee-columns");
-  if (!columns) return 0;
+  if (!columns) return false;
 
   const blocks = Array.from(columns.childNodes).filter(shouldKeepPreviewNode);
-
-  const stack = document.createElement("div");
-  stack.className = "ieee-page-stack";
 
   const first = createIeeePreviewPage(frontmatter ? frontmatter.cloneNode(true) : null);
   stack.appendChild(first.page);
 
-  // Attach stack before measuring overflow so clientHeight/geometry are valid.
-  layout.replaceWith(stack);
-
   let currentInner = first.inner;
   let currentColumns = first.columns;
-  blocks.forEach((block) => {
-    let nodeToPlace = block.cloneNode(true);
+  let sliceStart = performance.now();
 
+  for (const block of blocks) {
+    if (runToken !== ieeeRunToken) return false;
+
+    let nodeToPlace = block.cloneNode(true);
     while (nodeToPlace) {
+      // One long paragraph can span many pages, and each break costs a binary
+      // search over its words - so check the budget here, not just per block.
+      if (performance.now() - sliceStart > IEEE_PAGINATE_SLICE_MS) {
+        await yieldToEventLoop();
+        if (runToken !== ieeeRunToken) return false;
+        sliceStart = performance.now();
+      }
+
       currentColumns.appendChild(nodeToPlace);
       if (!hasPageOverflow(currentInner, currentColumns, nodeToPlace)) {
         nodeToPlace = null;
@@ -532,21 +943,104 @@ function paginateIeeePreview() {
         break;
       }
 
+      if (stack.childElementCount >= IEEE_MAX_PAGES) return false;
+
       const nextPage = createIeeePreviewPage();
       stack.appendChild(nextPage.page);
       currentInner = nextPage.inner;
       currentColumns = nextPage.columns;
     }
-  });
 
-  return stack.childElementCount;
+    if (performance.now() - sliceStart > IEEE_PAGINATE_SLICE_MS) {
+      await yieldToEventLoop();
+      if (runToken !== ieeeRunToken) return false;
+      sliceStart = performance.now();
+    }
+  }
+
+  return true;
 }
 
-function repaginateIeeePreview(markdown) {
-  markdownPreview.innerHTML = renderDocument(markdown, { ieeeLayout: true });
-  const pageCount = paginateIeeePreview();
-  requestAnimationFrame(() => requestAnimationFrame(applyIeeePreviewViewportFit));
-  return pageCount;
+/* Rebuilds the page stack and swaps it in once it is ready. The new pages are
+   measured in the document but out of sight, so what is on screen stays put -
+   otherwise every edit flashes the unpaginated layout and bounces the reader
+   back to page one. */
+async function repaginateIeeePreview(markdown) {
+  if (!md) return;
+  if (!markdownPreview.classList.contains("markdown-preview--ieee")) return;
+
+  const runToken = ++ieeeRunToken;
+
+  // Only cloned from, so it can stay detached.
+  const host = document.createElement("div");
+  host.innerHTML = getIeeeLayoutHtml(markdown);
+  const layout = host.querySelector(".ieee-paper-layout");
+  if (!layout) return;
+
+  const stack = document.createElement("div");
+  stack.className = "ieee-page-stack";
+
+  // Pages already showing: measure the new ones out of sight. Empty preview:
+  // build them in place so something appears right away.
+  let staging = null;
+  if (markdownPreview.querySelector(".ieee-page-stack")) {
+    staging = document.createElement("div");
+    staging.style.cssText = IEEE_STAGING_STYLE;
+    staging.appendChild(stack);
+    markdownPreview.appendChild(staging);
+  } else {
+    markdownPreview.appendChild(stack);
+  }
+
+  const startedAt = performance.now();
+  let completed = false;
+  try {
+    completed = await paginateIeeePreview(runToken, layout, stack);
+  } finally {
+    lastPaginateDurationMs = performance.now() - startedAt;
+    if (!completed || runToken !== ieeeRunToken) (staging || stack).remove();
+  }
+  if (!completed || runToken !== ieeeRunToken) return;
+
+  // Swapping children resets scroll. Restore before paint, and again after the
+  // fit scale changes the page heights.
+  const scrollTop = markdownPreview.scrollTop;
+  markdownPreview.replaceChildren(stack);
+  markdownPreview.scrollTop = scrollTop;
+  previewNeedsFullRender = true;
+
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    if (runToken !== ieeeRunToken) return;
+    applyIeeePreviewViewportFit();
+    markdownPreview.scrollTop = scrollTop;
+  }));
+}
+
+function scheduleIeeeRepagination(markdown) {
+  // Bump the token first so any run already in flight stops immediately.
+  ieeeRunToken += 1;
+  if (ieeeRepaginateTimer) clearTimeout(ieeeRepaginateTimer);
+  // Nothing on screen yet, or short enough to repaginate between keystrokes:
+  // go now. Slow papers wait for a pause in typing.
+  const delay = !markdownPreview.querySelector(".ieee-page-stack") ||
+    lastPaginateDurationMs <= IEEE_REPAGINATE_FAST_LIMIT_MS
+    ? 0
+    : IEEE_REPAGINATE_IDLE_MS;
+  ieeeRepaginateTimer = setTimeout(() => {
+    ieeeRepaginateTimer = null;
+    if ((markdownInput.value || "") !== markdown) return;
+    repaginateIeeePreview(markdown);
+  }, delay);
+
+  // Web fonts shift line metrics, so repaginate once they land - once, not on
+  // every render.
+  if (!ieeeFontsWatched && document.fonts?.ready) {
+    ieeeFontsWatched = true;
+    document.fonts.ready.then(() => {
+      if (!markdownPreview.classList.contains("markdown-preview--ieee")) return;
+      repaginateIeeePreview(markdownInput.value || "");
+    }).catch(() => {});
+  }
 }
 
 export function renderDocument(markdown, options = {}) {
@@ -562,14 +1056,19 @@ export function renderPreview() {
     return;
   }
 
+  const startedAt = performance.now();
   const markdown = markdownInput.value || "";
   if (typeof window.syncIeeeModeFromMarker === "function") {
     window.syncIeeeModeFromMarker(markdown);
   }
-  const hasSlides = /^---$|^<!-- slide -->$/gm.test(markdown);
+  const hasSlides = SLIDE_MARKER_RE.test(markdown);
   const useIeeeLayout = Boolean(window.latexModeEnabled && window.ieeeModeEnabled);
 
   if (hasSlides && window.autoRenderSlides) {
+    // Drop any pagination in flight, or it writes into a preview that slide
+    // mode has taken over.
+    ieeeRunToken += 1;
+    resetIncrementalPreview();
     markdownPreview.classList.remove("markdown-preview--ieee");
     window.autoRenderSlides();
   } else {
@@ -577,26 +1076,31 @@ export function renderPreview() {
       window.exitSlideMode();
     }
     markdownPreview.classList.toggle("markdown-preview--ieee", useIeeeLayout);
-    markdownPreview.innerHTML = renderDocument(markdown, { ieeeLayout: useIeeeLayout });
     if (useIeeeLayout) {
-      requestAnimationFrame(() => {
-        if ((markdownInput.value || "") !== markdown) return;
-        repaginateIeeePreview(markdown);
-
-        if (document.fonts?.ready) {
-          document.fonts.ready.then(() => {
-            if ((markdownInput.value || "") !== markdown) return;
-            repaginateIeeePreview(markdown);
-          });
-        }
-      });
+      resetIncrementalPreview();
+      // Coming from normal or slide rendering: clear it, pages take over.
+      // Existing pages stay until the new ones are ready.
+      if (!markdownPreview.querySelector(".ieee-page-stack")) {
+        markdownPreview.replaceChildren();
+      }
+      scheduleIeeeRepagination(markdown);
+    } else {
+      ieeeRunToken += 1;
+      renderPreviewIncremental(markdown);
     }
   }
+
+  lastRenderDurationMs = performance.now() - startedAt;
 }
 
 export function scheduleRender() {
   if (renderTimer) clearTimeout(renderTimer);
-  renderTimer = setTimeout(renderPreview, 120);
+  // Back off on documents that render slowly rather than burning every idle
+  // gap on a re-render.
+  const delay = lastRenderDurationMs > RENDER_SLOW_THRESHOLD_MS
+    ? RENDER_DEBOUNCE_SLOW_MS
+    : RENDER_DEBOUNCE_MS;
+  renderTimer = setTimeout(renderPreview, delay);
 }
 
 export function showSpinner(show) {

--- a/noteEditor.js
+++ b/noteEditor.js
@@ -116,8 +116,10 @@ export function initMarkdown() {
   }
 }
 
+/* Hides comment content but keeps its newlines, so token line numbers still
+   line up with the editor's lines. */
 function stripHtmlComments(markdown) {
-  return (markdown || "").replace(HTML_COMMENT_RE, "");
+  return (markdown || "").replace(HTML_COMMENT_RE, (comment) => comment.replace(/[^\n]/g, ""));
 }
 
 export function renderMarkdown(markdown) {
@@ -360,6 +362,7 @@ function prepareSyncMirror(text) {
     syncMirrorTextNode.nodeValue = `${text}\u200b`;
     syncMirrorText = text;
   }
+  return parseFloat(cs.lineHeight) || 20;
 }
 
 function syncLineStartsFor(text) {
@@ -385,11 +388,11 @@ function offsetTopInMirror(offset) {
   return rect.top;
 }
 
-/* Which source line the editor has scrolled to, plus how far into it. */
-function editorTopLine(text) {
+/* Which source line the editor has scrolled to, plus how far into it. The
+   fraction is what carries wrapping: a line that wraps over many visual rows
+   is tall, and scrolling through those rows walks the fraction from 0 to 1. */
+function editorTopLine(text, lineHeight) {
   const starts = syncLineStartsFor(text);
-  if (starts.length < 2) return { line: 0, fraction: 0 };
-
   const firstTop = offsetTopInMirror(0);
   const target = markdownInput.scrollTop;
   const topOf = (line) => offsetTopInMirror(starts[line]) - firstTop;
@@ -403,16 +406,23 @@ function editorTopLine(text) {
   }
 
   const lineTop = topOf(low);
-  const nextTop = low + 1 < starts.length ? topOf(low + 1) : lineTop;
+  // The last line has no next line to measure against - and a document that is
+  // one long wrapped line has none at all - so fall back to the end of the
+  // text, or scrolling inside that line would move nothing.
+  const nextTop = low + 1 < starts.length
+    ? topOf(low + 1)
+    : offsetTopInMirror(text.length) - firstTop + lineHeight;
   const height = nextTop - lineTop;
   const fraction = height > 0 ? Math.min(1, Math.max(0, (target - lineTop) / height)) : 0;
   return { line: low, fraction };
 }
 
-function blockTopInPreview(block, previewTop) {
-  const node = block.nodes.find((n) => n.nodeType === Node.ELEMENT_NODE);
+function blockEdgeInPreview(block, previewTop, edge) {
+  const nodes = block.nodes.filter((n) => n.nodeType === Node.ELEMENT_NODE);
+  const node = edge === "bottom" ? nodes[nodes.length - 1] : nodes[0];
   if (!node) return null;
-  return node.getBoundingClientRect().top - previewTop + markdownPreview.scrollTop;
+  const rect = node.getBoundingClientRect();
+  return (edge === "bottom" ? rect.bottom : rect.top) - previewTop + markdownPreview.scrollTop;
 }
 
 function syncPreviewProportionally() {
@@ -435,8 +445,8 @@ function syncPreviewToEditor() {
   const text = markdownInput.value || "";
   let target = null;
   try {
-    prepareSyncMirror(text);
-    const { line, fraction } = editorTopLine(text);
+    const lineHeight = prepareSyncMirror(text);
+    const { line, fraction } = editorTopLine(text, lineHeight);
 
     let low = 0;
     let high = previewBlocks.length - 1;
@@ -448,10 +458,12 @@ function syncPreviewToEditor() {
 
     const block = previewBlocks[low];
     const previewTop = markdownPreview.getBoundingClientRect().top;
-    const blockTop = blockTopInPreview(block, previewTop);
+    const blockTop = blockEdgeInPreview(block, previewTop, "top");
     if (blockTop !== null) {
       const next = previewBlocks[low + 1];
-      const nextTop = next ? blockTopInPreview(next, previewTop) : markdownPreview.scrollHeight;
+      const nextTop = next
+        ? blockEdgeInPreview(next, previewTop, "top")
+        : blockEdgeInPreview(block, previewTop, "bottom");
       const span = Math.max(1, block.endLine - block.startLine);
       const into = Math.min(1, Math.max(0, (line - block.startLine + fraction) / span));
       target = blockTop + ((nextTop ?? blockTop) - blockTop) * into;

--- a/p2p.js
+++ b/p2p.js
@@ -769,12 +769,20 @@ function truncateIdentifier(value, size = 10) {
 function getCursorDetails(text, offset) {
   const safeText = typeof text === "string" ? text : "";
   const safeOffset = Number.isFinite(offset) ? Math.max(0, Math.min(offset, safeText.length)) : 0;
-  const prefix = safeText.slice(0, safeOffset);
-  const lines = prefix.split("\n");
+  // Counted in place; splitting the prefix copied everything above the caret
+  // on every presence tick.
+  let line = 1;
+  let lastBreak = -1;
+  for (let i = 0; i < safeOffset; i += 1) {
+    if (safeText.charCodeAt(i) === 10) {
+      line += 1;
+      lastBreak = i;
+    }
+  }
   return {
     offset: safeOffset,
-    line: lines.length,
-    column: (lines[lines.length - 1] || "").length + 1
+    line,
+    column: safeOffset - lastBreak
   };
 }
 
@@ -1214,15 +1222,29 @@ export function scheduleSend() {
     sendTimer = null;
   }
   const newText = markdownInput.value;
-  const oldText = ytext ? ytext.toString() : prevText;
+  const oldText = getYTextSnapshot();
   if (newText === oldText) {
     prevText = oldText;
     return;
   }
-  applyTextDiff(ytext, oldText, newText, Y_ORIGIN_LOCAL);
-  _attributeLocalEditRange(oldText, newText);
+  // One diff for both the CRDT update and line attribution - each pass is a
+  // full-length scan on a long document.
+  const change = diffTextChange(oldText, newText);
+  applyTextDiff(ytext, oldText, newText, Y_ORIGIN_LOCAL, change);
+  _attributeLocalEditRange(oldText, newText, change);
   updateLineAuthors(_roomLineAttributions);
   prevText = newText;
+}
+
+// Current CRDT text without walking the CRDT. The observer fires on every
+// local and remote change, so prevText already holds what toString() would
+// rebuild - and rebuilding it per keystroke is what made long docs crawl. If
+// the lengths ever disagree, fall back to the real read rather than risk
+// diffing against a stale baseline.
+function getYTextSnapshot() {
+  if (!ytext) return prevText;
+  if (typeof prevText === "string" && prevText.length === ytext.length) return prevText;
+  return ytext.toString();
 }
 
 
@@ -1244,37 +1266,13 @@ function _attributeCurrentLine() {
   } catch {}
 }
 
-function _attributeLocalEditRange(oldText, newText) {
+function _attributeLocalEditRange(oldText, newText, change = null) {
   try {
     const oldValue = typeof oldText === "string" ? oldText : "";
     const newValue = typeof newText === "string" ? newText : "";
     if (oldValue === newValue) return;
 
-    let prefixLen = 0;
-    let oldSuffix = oldValue.length;
-    let newSuffix = newValue.length;
-
-    const isPurePrepend = newValue.length > oldValue.length && newValue.endsWith(oldValue);
-    const isPureAppend = newValue.length > oldValue.length && newValue.startsWith(oldValue);
-
-    if (isPurePrepend) {
-      prefixLen = 0;
-      oldSuffix = 0;
-      newSuffix = newValue.length - oldValue.length;
-    } else if (isPureAppend) {
-      prefixLen = oldValue.length;
-      oldSuffix = oldValue.length;
-      newSuffix = newValue.length;
-    } else {
-   
-      const minLen = Math.min(oldValue.length, newValue.length);
-      while (prefixLen < minLen && oldValue[prefixLen] === newValue[prefixLen]) prefixLen += 1;
-      while (oldSuffix > prefixLen && newSuffix > prefixLen &&
-            oldValue[oldSuffix - 1] === newValue[newSuffix - 1]) {
-        oldSuffix -= 1;
-        newSuffix -= 1;
-      }
-    }
+    const { prefixLen, oldSuffix, newSuffix } = change || diffTextChange(oldValue, newValue);
 
     const deleteLen = oldSuffix - prefixLen;
     const inserted = newValue.slice(prefixLen, newSuffix);
@@ -1618,9 +1616,15 @@ function syncLocalLineAttributionNames() {
 
 
 
+// Chunked, so a whole-document snapshot isn't built one character at a time.
+const BASE64_CHUNK_SIZE = 0x8000;
+
 function bytesToBase64(bytes) {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
   let binary = "";
-  for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < view.length; i += BASE64_CHUNK_SIZE) {
+    binary += String.fromCharCode.apply(null, view.subarray(i, i + BASE64_CHUNK_SIZE));
+  }
   return btoa(binary);
 }
 
@@ -1630,33 +1634,44 @@ function base64ToBytes(b64) {
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
 }
-function applyTextDiff(ytextRef, oldText, newText, origin = null) {
-  if (!ytextRef || oldText === newText) return;
-  let prefixLen = 0;
-  let oldSuffix = oldText.length;
-  let newSuffix = newText.length;
+// Finds the one changed run by trimming the common prefix and suffix. Callers
+// derive both the CRDT op and the touched line range from these boundaries.
+function diffTextChange(oldText, newText) {
+  const oldValue = typeof oldText === "string" ? oldText : "";
+  const newValue = typeof newText === "string" ? newText : "";
 
-  const isPurePrepend = newText.length > oldText.length && newText.endsWith(oldText);
-  const isPureAppend = newText.length > oldText.length && newText.startsWith(oldText);
+  let prefixLen = 0;
+  let oldSuffix = oldValue.length;
+  let newSuffix = newValue.length;
+
+  const isPurePrepend = newValue.length > oldValue.length && newValue.endsWith(oldValue);
+  const isPureAppend = newValue.length > oldValue.length && newValue.startsWith(oldValue);
 
   if (isPurePrepend) {
     prefixLen = 0;
     oldSuffix = 0;
-    newSuffix = newText.length - oldText.length;
+    newSuffix = newValue.length - oldValue.length;
   } else if (isPureAppend) {
-    prefixLen = oldText.length;
-    oldSuffix = oldText.length;
-    newSuffix = newText.length;
+    prefixLen = oldValue.length;
+    oldSuffix = oldValue.length;
+    newSuffix = newValue.length;
   } else {
     // Trim unchanged edges so we emit one minimal delete/insert change.
-    const minLen = Math.min(oldText.length, newText.length);
-    while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) prefixLen++;
+    const minLen = Math.min(oldValue.length, newValue.length);
+    while (prefixLen < minLen && oldValue[prefixLen] === newValue[prefixLen]) prefixLen++;
     while (oldSuffix > prefixLen && newSuffix > prefixLen &&
-          oldText[oldSuffix - 1] === newText[newSuffix - 1]) {
+          oldValue[oldSuffix - 1] === newValue[newSuffix - 1]) {
       oldSuffix--;
       newSuffix--;
     }
   }
+
+  return { prefixLen, oldSuffix, newSuffix };
+}
+
+function applyTextDiff(ytextRef, oldText, newText, origin = null, change = null) {
+  if (!ytextRef || oldText === newText) return;
+  const { prefixLen, oldSuffix, newSuffix } = change || diffTextChange(oldText, newText);
 
   const deleteLen = oldSuffix - prefixLen;
   const insertStr = newText.slice(prefixLen, newSuffix);
@@ -2371,7 +2386,8 @@ function connectSseChannel(localUrl, role) {
           const newEnd = Math.min(end, incoming.length);
           markdownInput.setSelectionRange(newStart, newEnd);
         }
-        renderPreview();
+        // A typing peer sends a stream of these; debounce like local input.
+        scheduleRender();
         scheduleDraftSave();
       } catch {}
     });
@@ -2724,7 +2740,7 @@ async function connectToRoom(localUrl, role = "client") {
       // Remote text applies do not fire input events; force gutter refresh so
       // previously-merged attribution lines are re-laid out against new content.
       updateLineAuthors(_roomLineAttributions);
-      renderPreview();
+      scheduleRender();
       scheduleDraftSave();
     });
   } else {

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,8 @@ main {
 
 #editor-page {
   padding-bottom: 55px;
+  /* Shrink to the window instead of growing to fit the preview. */
+  min-height: 0;
 }
 
 #setup-page #room-panel,
@@ -437,6 +439,9 @@ main {
 #editor-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  /* Without an explicit row the implicit one sizes to content, so a long
+     preview stretches the panel and the window ends up the only scrollbar. */
+  grid-template-rows: minmax(0, 1fr);
   gap: var(--gap);
   flex: 1;
   min-height: 40vh;
@@ -1401,6 +1406,11 @@ textarea {
 @media screen and (max-width: 768px) {
   #editor-panel {
     grid-template-columns: 1fr;
+    /* Stacked panes keep their own height and the window scrolls, as before. */
+    grid-template-rows: none;
+  }
+  #editor-page {
+    min-height: auto;
   }
   #dweb-container,
   #dweb-container > * {


### PR DESCRIPTION
| | before | after |
|---|---|---|
| Caret measurement, 203 positions on a 31 KB doc | 833 ms | 6.9 ms |
| Preview render, 180 KB doc (JS) | 148 ms | 23 ms |
| Preview render + layout, 180 KB doc | 456 ms | 290 ms |
| IEEE pagination, 12-page paper (longest main-thread block) | 3319 ms | 189 ms |
| Typing in a room, 54 KB doc / 226 attributed lines | did not finish 3 keystrokes in 30 s | 209 ms longest block |
| Preview scroll after an edit (IEEE, was at 1200) | 535 | 1200 |
| Unpaginated layout flash on edit | yes | no |

Tests:
<img width="567" height="56" alt="Screenshot 2026-08-09 at 8 44 11 PM" src="https://github.com/user-attachments/assets/e4cb5353-28d1-41f6-8580-b57755c28d85" />
